### PR TITLE
Backslashes path under Windows

### DIFF
--- a/gmplot/gmplot.py
+++ b/gmplot/gmplot.py
@@ -25,7 +25,7 @@ class GoogleMapPlotter(object):
         self.heatmap_points = []
         self.radpoints = []
         self.gridsetting = None
-        self.coloricon = os.path.join(os.path.dirname(__file__), 'markers/%s.png')
+        self.coloricon = os.path.join(os.path.dirname(__file__), 'markers/%s.png').replace('\\', '/')
         self.color_dict = mpl_color_map
         self.html_color_codes = html_color_codes
 


### PR DESCRIPTION
To address the issue in Windows of having backslashes in HTML:
...
var img = new google.maps.MarkerImage('C:\Anaconda3\lib\site-packages\gmplot\markers/000000.png');
...

Not sure if this is the best solution but worked for me.
