### PR TITLE
Include option to create satellite map by optional argument

### DIFF
--- a/gmplot/gmplot.py
+++ b/gmplot/gmplot.py
@@ -15,7 +15,7 @@ def safe_iter(var):
 
 class GoogleMapPlotter(object):
 
-    def __init__(self, center_lat, center_lng, zoom):
+    def __init__(self, center_lat, center_lng, zoom, map_type=None):
         self.center = (float(center_lat), float(center_lng))
         self.zoom = int(zoom)
         self.grids = None
@@ -28,6 +28,12 @@ class GoogleMapPlotter(object):
         self.coloricon = os.path.join(os.path.dirname(__file__), 'markers/%s.png')
         self.color_dict = mpl_color_map
         self.html_color_codes = html_color_codes
+
+        # option for satellite map, default is road map
+        if map_type == ('satellite' or 'Satellite' or 'SATELLITE'):
+            self.map_type = 'google.maps.MapTypeId.SATELLITE'
+        else:
+            self.map_type = 'google.maps.MapTypeId.ROADMAP'
 
     @classmethod
     def from_geocode(cls, location_string, zoom=13):
@@ -268,7 +274,7 @@ class GoogleMapPlotter(object):
         f.write('\t\tvar myOptions = {\n')
         f.write('\t\t\tzoom: %d,\n' % (self.zoom))
         f.write('\t\t\tcenter: centerlatlng,\n')
-        f.write('\t\t\tmapTypeId: google.maps.MapTypeId.ROADMAP\n')
+        f.write('\t\t\tmapTypeId: %s, \n' % (self.map_type))
         f.write('\t\t};\n')
         f.write(
             '\t\tvar map = new google.maps.Map(document.getElementById("map_canvas"), myOptions);\n')


### PR DESCRIPTION
Enables choice between satellite map and road map creation by including map_type argument in GoogleMapPlotter:

1. Create a satellite map if 'satellite' is provided as map_type argument
`gmap = gmplot.GoogleMapPlotter(37.428, -122.145, 16, 'satellite')`

2. Create a road map if map_type argument is None or not 'satellite' 
`gmap = gmplot.GoogleMapPlotter(37.428, -122.145, 16)`