### PR TITLE
Updated Marker Plotting to Refer to CDN for Marker Images 

### DIFF
--- a/gmplot/gmplot.py
+++ b/gmplot/gmplot.py
@@ -11,7 +11,6 @@ from collections import namedtuple
 from gmplot.color_dicts import mpl_color_map, html_color_codes
 from gmplot.google_maps_templates import SYMBOLS, CIRCLE
 
-
 Symbol = namedtuple('Symbol', ['symbol', 'lat', 'long', 'size'])
 
 
@@ -42,10 +41,11 @@ class GoogleMapPlotter(object):
         self.ground_overlays = []
         self.radpoints = []
         self.gridsetting = None
-        #self.coloricon = os.path.join(os.path.dirname(__file__), 'markers/%s.png')
-        self.coloricon = 'https://cdn.rawgit.com/vgm64/gmplot/e3bc4f70/gmplot/markers/%s.png'
 
-
+        try:
+            self.coloricon = 'https://rawcdn.githack.com/vgm64/gmplot/master/gmplot/markers/%s.png'
+        except:
+            self.coloricon = os.path.join(os.path.dirname(__file__), 'markers/%s.png')
 
         self.color_dict = mpl_color_map
         self.html_color_codes = html_color_codes
@@ -146,7 +146,8 @@ class GoogleMapPlotter(object):
         path = zip(lats, lngs)
         self.paths.append((path, settings))
 
-    def heatmap(self, lats, lngs, threshold=10, radius=10, gradient=None, opacity=0.6, maxIntensity=1, dissipating=True):
+    def heatmap(self, lats, lngs, threshold=10, radius=10, gradient=None, opacity=0.6, maxIntensity=1,
+                dissipating=True):
         """
         :param lats: list of latitudes
         :param lngs: list of longitudes
@@ -242,9 +243,11 @@ class GoogleMapPlotter(object):
             '<meta http-equiv="content-type" content="text/html; charset=UTF-8"/>\n')
         f.write('<title>Google Maps - gmplot </title>\n')
         if self.apikey:
-            f.write('<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?libraries=visualization&sensor=true_or_false&key=%s"></script>\n' % self.apikey )
+            f.write(
+                '<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?libraries=visualization&sensor=true_or_false&key=%s"></script>\n' % self.apikey)
         else:
-            f.write('<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?libraries=visualization&sensor=true_or_false"></script>\n' )
+            f.write(
+                '<script type="text/javascript" src="https://maps.googleapis.com/maps/api/js?libraries=visualization&sensor=true_or_false"></script>\n')
         f.write('<script type="text/javascript">\n')
         f.write('\tfunction initialize() {\n')
         self.write_map(f)
@@ -319,7 +322,7 @@ class GoogleMapPlotter(object):
             self.write_polygon(f, shape, settings)
 
     # TODO: Add support for mapTypeId: google.maps.MapTypeId.SATELLITE
-    def write_map(self,  f):
+    def write_map(self, f):
         f.write('\t\tvar centerlatlng = new google.maps.LatLng(%f, %f);\n' %
                 (self.center[0], self.center[1]))
         f.write('\t\tvar myOptions = {\n')
@@ -402,7 +405,7 @@ class GoogleMapPlotter(object):
         strokeOpacity = settings.get('edge_alpha')
         strokeWeight = settings.get('edge_width')
         fillColor = settings.get('face_color') or settings.get('color')
-        fillOpacity= settings.get('face_alpha')
+        fillOpacity = settings.get('face_alpha')
         f.write('var coords = [\n')
         for coordinate in path:
             f.write('new google.maps.LatLng(%f, %f),\n' %
@@ -452,8 +455,8 @@ class GoogleMapPlotter(object):
             f.write('imageBounds);' + '\n')
             f.write('groundOverlay.setMap(map);' + '\n')
 
-if __name__ == "__main__":
 
+if __name__ == "__main__":
     mymap = GoogleMapPlotter(37.428, -122.145, 16)
     # mymap = GoogleMapPlotter.from_geocode("Stanford University")
 
@@ -465,21 +468,27 @@ if __name__ == "__main__":
     mymap.marker(lat, lng, "red")
     mymap.circle(37.429, -122.145, 100, "#FF0000", ew=2)
     path = [(37.429, 37.428, 37.427, 37.427, 37.427),
-             (-122.145, -122.145, -122.145, -122.146, -122.146)]
-    path2 = [[i+.01 for i in path[0]], [i+.02 for i in path[1]]]
-    path3 = [(37.433302 , 37.431257 , 37.427644 , 37.430303), (-122.14488, -122.133121, -122.137799, -122.148743)]
-    path4 = [(37.423074, 37.422700, 37.422410, 37.422188, 37.422274, 37.422495, 37.422962, 37.423552, 37.424387, 37.425920, 37.425937),
-         (-122.150288, -122.149794, -122.148936, -122.148142, -122.146747, -122.14561, -122.144773, -122.143936, -122.142992, -122.147863, -122.145953)]
+            (-122.145, -122.145, -122.145, -122.146, -122.146)]
+    path2 = [[i + .01 for i in path[0]], [i + .02 for i in path[1]]]
+    path3 = [(37.433302, 37.431257, 37.427644, 37.430303), (-122.14488, -122.133121, -122.137799, -122.148743)]
+    path4 = [(37.423074, 37.422700, 37.422410, 37.422188, 37.422274, 37.422495, 37.422962, 37.423552, 37.424387,
+              37.425920, 37.425937),
+             (-122.150288, -122.149794, -122.148936, -122.148142, -122.146747, -122.14561, -122.144773, -122.143936,
+              -122.142992, -122.147863, -122.145953)]
     mymap.plot(path[0], path[1], "plum", edge_width=10)
     mymap.plot(path2[0], path2[1], "red")
     mymap.polygon(path3[0], path3[1], edge_color="cyan", edge_width=5, face_color="blue", face_alpha=0.1)
     mymap.heatmap(path4[0], path4[1], threshold=10, radius=40)
-    mymap.heatmap(path3[0], path3[1], threshold=10, radius=40, dissipating=False, gradient=[(30,30,30,0), (30,30,30,1), (50, 50, 50, 1)])
+    mymap.heatmap(path3[0], path3[1], threshold=10, radius=40, dissipating=False,
+                  gradient=[(30, 30, 30, 0), (30, 30, 30, 1), (50, 50, 50, 1)])
     mymap.scatter(path4[0], path4[1], c='r', marker=True)
     mymap.scatter(path4[0], path4[1], s=90, marker=False, alpha=0.9, symbol='x', c='red', edge_width=4)
     # Get more points with:
     # http://www.findlatitudeandlongitude.com/click-lat-lng-list/
-    scatter_path = ([37.424435, 37.424417, 37.424417, 37.424554, 37.424775, 37.425099, 37.425235, 37.425082, 37.424656, 37.423957, 37.422952, 37.421759, 37.420447, 37.419135, 37.417822, 37.417209],
-                    [-122.142048, -122.141275, -122.140503, -122.139688, -122.138872, -122.138078, -122.137241, -122.136405, -122.135568, -122.134731, -122.133894, -122.133057, -122.13222, -122.131383, -122.130557, -122.129999])
+    scatter_path = (
+        [37.424435, 37.424417, 37.424417, 37.424554, 37.424775, 37.425099, 37.425235, 37.425082, 37.424656, 37.423957,
+         37.422952, 37.421759, 37.420447, 37.419135, 37.417822, 37.417209],
+        [-122.142048, -122.141275, -122.140503, -122.139688, -122.138872, -122.138078, -122.137241, -122.136405,
+         -122.135568, -122.134731, -122.133894, -122.133057, -122.13222, -122.131383, -122.130557, -122.129999])
     mymap.scatter(scatter_path[0], scatter_path[1], c='r', marker=True)
     mymap.draw('./mymap.html')

--- a/gmplot/gmplot.py
+++ b/gmplot/gmplot.py
@@ -42,7 +42,11 @@ class GoogleMapPlotter(object):
         self.ground_overlays = []
         self.radpoints = []
         self.gridsetting = None
-        self.coloricon = os.path.join(os.path.dirname(__file__), 'markers/%s.png')
+        #self.coloricon = os.path.join(os.path.dirname(__file__), 'markers/%s.png')
+        self.coloricon = 'https://cdn.rawgit.com/vgm64/gmplot/e3bc4f70/gmplot/markers/%s.png'
+
+
+
         self.color_dict = mpl_color_map
         self.html_color_codes = html_color_codes
 


### PR DESCRIPTION
I updated the gmplot.py to refer to a github cdn, so that when the html map is created, it creates image without having to rely on the local machines file directory.

This is to:
1. Solve the issue where Marker images won't load on window machines.
2. Allow users to transfer their html maps to other users without a loss of markers.