### PR TITLE
Define all API defaults in public functions only.

### DIFF
--- a/gmplot/color.py
+++ b/gmplot/color.py
@@ -1,5 +1,4 @@
 import re
-import warnings
 
 _MATPLOTLIB_COLOR_MAP = {
     'b': 'blue',
@@ -163,18 +162,6 @@ _HTML_COLOR_CODES = {
     'yellowgreen':          '#9ACD32'
 }
 
-def _is_valid_hex_color(color):
-    '''
-    Return whether or not a given color is a valid hex color.
-
-    Args:
-        color (str): Color to check.
-
-    Returns:
-        bool: True if the given color is a valid hex color, False otherwise.
-    '''
-    return bool(isinstance(color, str) and re.match('^#[0-9a-fA-F]{6}$', color))
-
 def _get_hex_color(color):
     '''
     Return the hex color code for a given color.
@@ -184,14 +171,16 @@ def _get_hex_color(color):
 
     Returns:
         str: Hex color code for the given color.
+
+    Raises:
+        ValueError: If the color isn't supported.
     '''
-    if not _is_valid_hex_color(color):
+    if not re.match('^#[0-9a-fA-F]{6}$', color):
         color = _MATPLOTLIB_COLOR_MAP.get(color, color)
 
-        if color in _HTML_COLOR_CODES:
-            color = _HTML_COLOR_CODES[color]
-        else:
-            warnings.warn("Color '%s' isn't supported." % color)
-            color = '#000000'
+        if color not in _HTML_COLOR_CODES:
+            raise ValueError("Color '%s' isn't supported!" % color)
+
+        color = _HTML_COLOR_CODES[color]
 
     return color.upper()

--- a/gmplot/drawables/grid.py
+++ b/gmplot/drawables/grid.py
@@ -3,22 +3,21 @@ import math
 from gmplot.drawables.polyline import _Polyline
 
 class _Grid(object):
-    def __init__(self, bounds, lat_increment, lng_increment, **kwargs):
+    def __init__(self, bounds, lat_increment, lng_increment, precision, **kwargs):
         '''
         Args:
             bounds (dict): Grid bounds, as a dict of the form
                 ``{'north': float, 'south': float, 'east': float, 'west': float}``.
             lat_increment (float): Distance between latitudinal divisions.
             lng_increment (float): Distance between longitudinal divisions.
+            precision (int): Number of digits after the decimal to round to for lat/lng values.
 
         Optional:
 
         Args:
-            color/c/edge_color/ec (str): Color of the grid.
-                Can be hex ('#00FFFF'), named ('cyan'), or matplotlib-like ('c'). Defaults to black.
-            alpha/edge_alpha/ea (float): Opacity of the grid, ranging from 0 to 1. Defaults to 1.0.
-            edge_width/ew (int): Width of the grid lines, in pixels. Defaults to 1.
-            precision (int): Number of digits after the decimal to round to for lat/lng values. Defaults to 6.
+            color (str): Grid color. Can be hex ('#00FFFF'), named ('cyan'), or matplotlib-like ('c').
+            alpha (float): Opacity of the grid, ranging from 0 to 1.
+            width (int): Width of the grid lines, in pixels.
         '''
         # Set up the bounding box:
         self._bounding_box = _Polyline(*zip(*[
@@ -27,7 +26,7 @@ class _Grid(object):
             (bounds['north'], bounds['east']),
             (bounds['south'], bounds['east']),
             (bounds['south'], bounds['west'])
-        ]), **kwargs)
+        ]), precision=precision, **kwargs)
 
         get_num_divisions = lambda start, end, increment: int(math.ceil((end - start) / increment))
 
@@ -35,13 +34,13 @@ class _Grid(object):
         self._lat_divisions = []
         for lat_index in range(1, get_num_divisions(bounds['south'], bounds['north'], lat_increment)):
             lat = bounds['south'] + float(lat_index) * lat_increment
-            self._lat_divisions.append(_Polyline(*zip(*[(lat, bounds['west']), (lat, bounds['east'])]), **kwargs))
+            self._lat_divisions.append(_Polyline(*zip(*[(lat, bounds['west']), (lat, bounds['east'])]), precision=precision, **kwargs))
 
         # Set up the longitudinal divisions:
         self._lng_divisions = []
         for lng_index in range(1, get_num_divisions(bounds['west'], bounds['east'], lng_increment)):
             lng = bounds['west'] + float(lng_index) * lng_increment
-            self._lng_divisions.append(_Polyline(*zip(*[(bounds['south'], lng), (bounds['north'], lng)]), **kwargs))
+            self._lng_divisions.append(_Polyline(*zip(*[(bounds['south'], lng), (bounds['north'], lng)]), precision=precision, **kwargs))
 
     def write(self, w):
         '''

--- a/gmplot/drawables/ground_overlay.py
+++ b/gmplot/drawables/ground_overlay.py
@@ -1,7 +1,5 @@
 import json
 
-from gmplot.utility import _get_value
-
 class _GroundOverlay(object):
     def __init__(self, url, bounds, **kwargs):
         '''
@@ -13,11 +11,11 @@ class _GroundOverlay(object):
         Optional:
 
         Args:
-            opacity (float): Opacity of the overlay, ranging from 0 to 1. Defaults to 1.0.
+            opacity (float): Opacity of the overlay, ranging from 0 to 1.
         '''
         self._url = url
         self._bounds = bounds
-        self._opacity = _get_value(kwargs, ['opacity'], 1.0)
+        self._opacity = kwargs.get('opacity')
 
     def write(self, w):
         '''
@@ -26,19 +24,17 @@ class _GroundOverlay(object):
         Args:
             w (_Writer): Writer used to write the ground overlay.
         '''
-        w.write('''
-            new google.maps.GroundOverlay(
-                "{url}",
-                {bounds},
-                {{
-                    opacity: {opacity},
-                    map: map,
-                    clickable: false
-                }}
-            );
-        '''.format(
-            url=self._url,
-            bounds=json.dumps(self._bounds),
-            opacity=self._opacity
-        ))
+        w.write('new google.maps.GroundOverlay(')
+        w.indent()
+        w.write('"%s",' % self._url)
+        w.write('%s,' % json.dumps(self._bounds))
+        w.write('{')
+        w.indent()
+        if self._opacity is not None: w.write('opacity: %s,' % self._opacity)
+        w.write('map: map,')
+        w.write('clickable: false')
+        w.dedent()
+        w.write('}')
+        w.dedent()
+        w.write(');')
         w.write()

--- a/gmplot/drawables/heatmap.py
+++ b/gmplot/drawables/heatmap.py
@@ -1,43 +1,40 @@
 from collections import namedtuple
 
-from gmplot.utility import _get_value, _format_LatLng
+from gmplot.utility import _get, _format_LatLng
 
 class _Heatmap(object):
     _DEFAULT_WEIGHT = 1
 
     _Point = namedtuple('Point', ['location', 'weight'])
 
-    def __init__(self, lats, lngs, **kwargs):
+    def __init__(self, lats, lngs, precision, **kwargs):
         '''
         Args:
             lats ([float]): Latitudes.
             lngs ([float]): Longitudes.
+            precision (int): Number of digits after the decimal to round to for lat/lng values.
 
         Optional:
 
         Args:
-            radius (int): Radius of influence for each data point, in pixels. Defaults to 10.
+            radius (int): Radius of influence for each data point, in pixels.
             gradient ([(int, int, int, float)]): Color gradient of the heatmap, as a list of `RGBA`_ colors.
                 The color order defines the gradient moving towards the center of a point.
-            opacity (float): Opacity of the heatmap, ranging from 0 to 1. Defaults to 0.6.
-            max_intensity (int): Maximum intensity of the heatmap. Defaults to 1.
-            dissipating (bool): True to dissipate the heatmap on zooming, False to disable dissipation. Defaults to True.
-            precision (int): Number of digits after the decimal to round to for lat/lng values. Defaults to 6.
+            opacity (float): Opacity of the heatmap, ranging from 0 to 1.
+            max_intensity (int): Maximum intensity of the heatmap.
+            dissipating (bool): True to dissipate the heatmap on zooming, False to disable dissipation.
             weights ([float]): List of weights corresponding to each data point. Each point has a weight
                 of 1 by default. Specifying a weight of N is equivalent to plotting the same point N times.
         
         .. _RGBA: https://www.w3.org/TR/css-color-3/#rgba-color
         '''
-        self._radius = _get_value(kwargs, ['radius'], 10)
-        self._gradient = _get_value(kwargs, ['gradient'], [])
-        self._opacity = _get_value(kwargs, ['opacity'], 0.6)
-        self._max_intensity = _get_value(kwargs, ['max_intensity'], 1)
-        self._dissipating = _get_value(kwargs, ['dissipating'], True)
-
-        precision = _get_value(kwargs, ['precision'], 6)
-        weights = _get_value(kwargs, ['weights'], [self._DEFAULT_WEIGHT] * len(lats))
-
+        weights = _get(kwargs, ['weights'], [self._DEFAULT_WEIGHT] * len(lats))
         self._points = [self._Point(_format_LatLng(lat, lng, precision), weight) for lat, lng, weight in zip(lats, lngs, weights)]
+        self._radius = kwargs.get('radius')
+        self._gradient = kwargs.get('gradient')
+        self._opacity = kwargs.get('opacity')
+        self._max_intensity = kwargs.get('max_intensity')
+        self._dissipating = kwargs.get('dissipating')
 
     def write(self, w):
         '''
@@ -48,10 +45,10 @@ class _Heatmap(object):
         '''
         w.write('new google.maps.visualization.HeatmapLayer({')
         w.indent()
-        w.write('radius: %d,' % self._radius)
-        w.write('maxIntensity: %d,' % self._max_intensity)
-        w.write('opacity: %f,' % self._opacity)
-        w.write('dissipating: %s,' % str(self._dissipating).lower())
+        if self._radius is not None: w.write('radius: %d,' % self._radius)
+        if self._max_intensity is not None: w.write('maxIntensity: %d,' % self._max_intensity)
+        if self._opacity is not None: w.write('opacity: %f,' % self._opacity)
+        if self._dissipating is False: w.write('dissipating: false,')
         if self._gradient:
             w.write('gradient: [')
             w.indent()

--- a/gmplot/drawables/map.py
+++ b/gmplot/drawables/map.py
@@ -1,14 +1,15 @@
 import json
 
-from gmplot.utility import _INDENT_LEVEL, _get_value, _format_LatLng
+from gmplot.utility import _INDENT_LEVEL, _format_LatLng
 
 class _Map(object):
-    def __init__(self, lat, lng, zoom, **kwargs):
+    def __init__(self, lat, lng, zoom, precision, **kwargs):
         '''
         Args:
             lat (float): Latitude of the center of the map.
             lng (float): Longitude of the center of the map.
             zoom (int): `Zoom level`_, where 0 is fully zoomed out.
+            precision (int): Number of digits after the decimal to round to for the lat/lng center.
 
         Optional:
 
@@ -16,10 +17,9 @@ class _Map(object):
             map_type (str): `Map type`_.
             map_styles ([dict]): `Map styles`_. Requires `Maps JavaScript API`_.
             tilt (int): `Tilt`_ of the map upon zooming in.
-            scale_control (bool): Whether or not to display the `scale control`_. Defaults to False.
+            scale_control (bool): Whether or not to display the `scale control`_.
             fit_bounds (dict): Fit the map to contain the given bounds, as a dict of the form
                 ``{'north': float, 'south': float, 'east': float, 'west': float}``.
-            precision (int): Number of digits after the decimal to round to for the lat/lng center. Defaults to 6.
 
         .. _Zoom level: https://developers.google.com/maps/documentation/javascript/tutorial#zoom-levels
         .. _Map type: https://developers.google.com/maps/documentation/javascript/maptypes
@@ -28,14 +28,13 @@ class _Map(object):
         .. _Tilt: https://developers.google.com/maps/documentation/javascript/reference/map#MapOptions.tilt
         .. _scale control: https://developers.google.com/maps/documentation/javascript/reference/map#MapOptions.scaleControl
         '''
-        precision = _get_value(kwargs, ['precision'], 6)
         self._center = _format_LatLng(lat, lng, precision)
         self._zoom = zoom
-        self._map_type = _get_value(kwargs, ['map_type'])
-        self._map_styles = _get_value(kwargs, ['map_styles'], [])
-        self._tilt = _get_value(kwargs, ['tilt'])
-        self._scale_control = _get_value(kwargs, ['scale_control'], False)
-        self._fit_bounds = _get_value(kwargs, ['fit_bounds'])
+        self._map_type = kwargs.get('map_type')
+        self._map_styles = kwargs.get('map_styles')
+        self._tilt = kwargs.get('tilt')
+        self._scale_control = kwargs.get('scale_control')
+        self._fit_bounds = kwargs.get('fit_bounds')
 
     def write(self, w):
         '''
@@ -47,7 +46,7 @@ class _Map(object):
         w.write('var map = new google.maps.Map(document.getElementById("map_canvas"), {')
         w.indent()
         if self._map_styles: w.write('styles: %s,' % json.dumps(self._map_styles, indent=_INDENT_LEVEL))
-        if self._map_type: w.write('mapTypeId: "%s",' % self._map_type.lower())
+        if self._map_type is not None: w.write('mapTypeId: "%s",' % self._map_type.lower())
         if self._tilt is not None: w.write('tilt: %d,' % self._tilt)
         if self._scale_control: w.write('scaleControl: true,')
         w.write('zoom: %d,' % self._zoom)

--- a/gmplot/drawables/marker.py
+++ b/gmplot/drawables/marker.py
@@ -1,39 +1,38 @@
-from gmplot.color import _get_hex_color
-from gmplot.utility import _get_value, _format_LatLng
-
+from gmplot.utility import _format_LatLng
 from gmplot.drawables.marker_icon import _MarkerIcon
 from gmplot.drawables.marker_info_window import _MarkerInfoWindow
 from gmplot.drawables.raw_marker import _RawMarker
 
 class _Marker(object):
-    def __init__(self, lat, lng, **kwargs):
+    def __init__(self, lat, lng, color, precision, **kwargs):
         '''
         Args:
             lat (float): Latitude of the marker.
             lng (float): Longitude of the marker.
+            color (str): Marker color. Can be hex ('#00FFFF'), named ('cyan'), or matplotlib-like ('c').
+            precision (int): Number of digits after the decimal to round to for lat/lng values.
 
         Optional:
 
         Args:
-            color/c/face_color/fc (str): Marker color. Can be hex ('#00FFFF'), named ('cyan'), or matplotlib-like ('c'). Defaults to red.
             title (str): Hover-over title of the marker.
             label (str): Label displayed on the marker.
             info_window (str): HTML content to be displayed in a pop-up `info window`_.
-            draggable (bool): Whether or not the marker is `draggable`_. Defaults to False.
-            precision (int): Number of digits after the decimal to round to for lat/lng values. Defaults to 6.
+            draggable (bool): Whether or not the marker is `draggable`_.
 
         .. _info window: https://developers.google.com/maps/documentation/javascript/infowindows
         .. _draggable: https://developers.google.com/maps/documentation/javascript/markers#draggable
         '''
-        color = _get_hex_color(_get_value(kwargs, ['color', 'c', 'face_color', 'fc'], 'red', pop=True))
         self._marker_icon = _MarkerIcon(color)
 
-        self._info_window = _get_value(kwargs, ['info_window'], pop=True)
-        if self._info_window is not None:
-            self._marker_info_window = _MarkerInfoWindow(self._info_window)
+        info_window = kwargs.pop('info_window', None)
+        self._marker_info_window = _MarkerInfoWindow(info_window) if info_window is not None else None
 
-        precision = _get_value(kwargs, ['precision'], 6, pop=True)
-        self._raw_marker = _RawMarker(_format_LatLng(lat, lng, precision), self._marker_icon.get_name(), **kwargs)
+        self._raw_marker = _RawMarker(
+            _format_LatLng(lat, lng, precision),
+            self._marker_icon.get_name(),
+            **kwargs
+        ) 
 
     def write(self, w, context):
         '''
@@ -47,7 +46,7 @@ class _Marker(object):
         self._marker_icon.write(w, context)
 
         # If this marker has no associated info window, just write the marker as is:
-        if self._info_window is None:
+        if self._marker_info_window is None:
             self._raw_marker.write(w)
 
         # Otherwise, write the marker with its info window:

--- a/gmplot/drawables/marker_dropper.py
+++ b/gmplot/drawables/marker_dropper.py
@@ -1,4 +1,3 @@
-from gmplot.utility import _get_value
 from gmplot.drawables.marker_icon import _MarkerIcon
 from gmplot.drawables.raw_marker import _RawMarker
 
@@ -11,20 +10,24 @@ class _MarkerDropper(object):
     _MARKER_NAME = 'dropped_marker'
     _EVENT_OBJECT_NAME = 'event'
 
-    def __init__(self, **kwargs):
+    def __init__(self, color, **kwargs):
         '''
-        Optional:
-
         Args:
-            color/c (str): Color of the markers to be dropped. Can be hex ('#00FFFF'), named ('cyan'),
-                or matplotlib-like ('c'). Defaults to red.
+            color (str): Color of the markers to be dropped. Can be hex ('#00FFFF'), named ('cyan'), or matplotlib-like ('c').
+
+        Optional:
+        
+        Args:
             title (str): Hover-over title of the markers to be dropped.
             label (str): Label displayed on the markers to be dropped.
-            draggable (bool): Whether or not the markers to be dropped are draggable. Defaults to False.
+            draggable (bool): Whether or not the markers to be dropped are draggable.
         '''
-        color = _get_hex_color(_get_value(kwargs, ['color', 'c'], 'red', pop=True))
         self._marker_icon = _MarkerIcon(color)
-        self._marker = _RawMarker('%s.latLng' % self._EVENT_OBJECT_NAME, self._marker_icon.get_name(), **kwargs)
+        self._marker = _RawMarker(
+            '%s.latLng' % self._EVENT_OBJECT_NAME,
+            self._marker_icon.get_name(),
+            **kwargs
+        )
 
     def write(self, w, context):
         '''

--- a/gmplot/drawables/marker_icon.py
+++ b/gmplot/drawables/marker_icon.py
@@ -8,7 +8,7 @@ class _MarkerIcon(object):
     def __init__(self, color):
         '''
         Args:
-            color (str): Color of the marker icon.
+            color (str): Marker icon color. Can be hex ('#00FFFF'), named ('cyan'), or matplotlib-like ('c').
         '''
         self._color = _get_hex_color(color)
         self._name = 'marker_icon_%s' % self._color[1:]
@@ -18,7 +18,7 @@ class _MarkerIcon(object):
         marker_icon_path = get_marker_icon_path(self._color)
 
         if not os.path.exists(marker_icon_path):
-            warnings.warn(" Marker color '%s' isn't supported." % self._color)
+            warnings.warn(" Marker color '%s' isn't supported; defaulting to black." % self._color)
             marker_icon_path = get_marker_icon_path('#000000')
 
         self._icon = _get_embeddable_image(marker_icon_path)

--- a/gmplot/drawables/polygon.py
+++ b/gmplot/drawables/polygon.py
@@ -1,34 +1,35 @@
 from gmplot.color import _get_hex_color
-from gmplot.utility import _get_value, _format_LatLng
+from gmplot.utility import _format_LatLng
 
 class _Polygon(object):
-    def __init__(self, lats, lngs, **kwargs):
+    def __init__(self, lats, lngs, precision, **kwargs):
         '''
         Args:
             lats ([float]): Latitudes.
             lngs ([float]): Longitudes.
+            precision (int): Number of digits after the decimal to round to for lat/lng values.
 
         Optional:
 
         Args:
-            color/c/edge_color/ec (str): Color of the polygon's edge.
-                Can be hex ('#00FFFF'), named ('cyan'), or matplotlib-like ('c'). Defaults to black.
-            alpha/edge_alpha/ea (float): Opacity of the polygon's edge, ranging from 0 to 1. Defaults to 1.0.
-            edge_width/ew (int): Width of the polygon's edge, in pixels. Defaults to 1.
-            color/c/face_color/fc (str): Color of the polygon's face.
-                Can be hex ('#00FFFF'), named ('cyan'), or matplotlib-like ('c'). Defaults to black.
-            alpha/face_alpha/fa (float): Opacity of the polygon's face, ranging from 0 to 1. Defaults to 0.3.
-            precision (int): Number of digits after the decimal to round to for lat/lng values. Defaults to 6.
+            edge_color (str): Color of the polygon's edge. Can be hex ('#00FFFF'), named ('cyan'), or matplotlib-like ('c').
+            edge_alpha (float): Opacity of the polygon's edge, ranging from 0 to 1.
+            edge_width (int): Width of the polygon's edge, in pixels.
+            face_color (str): Color of the polygon's face. Can be hex ('#00FFFF'), named ('cyan'), or matplotlib-like ('c').
+            face_alpha (float): Opacity of the polygon's face, ranging from 0 to 1.
         '''
-        self._edge_color = _get_hex_color(_get_value(kwargs, ['color', 'c', 'edge_color', 'ec'], 'black'))
-        self._edge_alpha = _get_value(kwargs, ['alpha', 'edge_alpha', 'ea'], 1.0)
-        self._edge_width = _get_value(kwargs, ['edge_width', 'ew'], 1)
-        self._face_alpha = _get_value(kwargs, ['alpha', 'face_alpha', 'fa'], 0.3)
-        self._face_color = _get_hex_color(_get_value(kwargs, ['color', 'c', 'face_color', 'fc'], 'black'))
-
-        precision = _get_value(kwargs, ['precision'], 6)
-
         self._points = [_format_LatLng(lat, lng, precision) for lat, lng in zip(lats, lngs)]
+                
+        edge_color = kwargs.get('edge_color')
+        self._edge_color = _get_hex_color(edge_color) if edge_color is not None else None
+
+        self._edge_alpha = kwargs.get('edge_alpha')
+        self._edge_width = kwargs.get('edge_width')
+
+        face_color = kwargs.get('face_color')
+        self._face_color = _get_hex_color(face_color) if face_color is not None else None
+
+        self._face_alpha = kwargs.get('face_alpha')
 
     def write(self, w):
         '''
@@ -41,11 +42,11 @@ class _Polygon(object):
         w.indent()
         w.write('clickable: false,')
         w.write('geodesic: true,')
-        w.write('fillColor: "%s",' % self._face_color)
-        w.write('fillOpacity: %f,' % self._face_alpha)
-        w.write('strokeColor: "%s",' % self._edge_color)
-        w.write('strokeOpacity: %f,' % self._edge_alpha)
-        w.write('strokeWeight: %d,' % self._edge_width)
+        if self._edge_color is not None: w.write('strokeColor: "%s",' % self._edge_color)
+        if self._edge_alpha is not None: w.write('strokeOpacity: %f,' % self._edge_alpha)
+        if self._edge_width is not None: w.write('strokeWeight: %d,' % self._edge_width)
+        if self._face_color is not None: w.write('fillColor: "%s",' % self._face_color)
+        if self._face_alpha is not None: w.write('fillOpacity: %f,' % self._face_alpha)
         w.write('map: map,')
         w.write('paths: [')
         w.indent()

--- a/gmplot/drawables/polyline.py
+++ b/gmplot/drawables/polyline.py
@@ -1,29 +1,26 @@
 from gmplot.color import _get_hex_color
-from gmplot.utility import _get_value, _format_LatLng
+from gmplot.utility import _format_LatLng
 
 class _Polyline(object):
-    def __init__(self, lats, lngs, **kwargs):
+    def __init__(self, lats, lngs, precision, **kwargs):
         '''
         Args:
             lats ([float]): Latitudes.
             lngs ([float]): Longitudes.
+            precision (int): Number of digits after the decimal to round to for lat/lng values.
 
         Optional:
 
         Args:
-            color/c/edge_color/ec (str): Color of the polyline.
-                Can be hex ('#00FFFF'), named ('cyan'), or matplotlib-like ('c'). Defaults to black.
-            alpha/edge_alpha/ea (float): Opacity of the polyline, ranging from 0 to 1. Defaults to 1.0.
-            edge_width/ew (int): Width of the polyline, in pixels. Defaults to 1.
-            precision (int): Number of digits after the decimal to round to for lat/lng values. Defaults to 6.
+            color (str): Color of the polyline. Can be hex ('#00FFFF'), named ('cyan'), or matplotlib-like ('c').
+            alpha (float): Opacity of the polyline, ranging from 0 to 1.
+            width (int): Width of the polyline, in pixels.
         '''
-        self._color = _get_hex_color(_get_value(kwargs, ['color', 'c', 'edge_color', 'ec'], 'black'))
-        self._edge_alpha = _get_value(kwargs, ['alpha', 'edge_alpha', 'ea'], 1.0)
-        self._edge_width = _get_value(kwargs, ['edge_width', 'ew'], 1)
-
-        precision = _get_value(kwargs, ['precision'], 6)
-
         self._points = [_format_LatLng(lat, lng, precision) for lat, lng in zip(lats, lngs)]
+        color = kwargs.get('color')
+        self._color = _get_hex_color(color) if color is not None else None
+        self._alpha = kwargs.get('alpha')
+        self._width = kwargs.get('width')
 
     def write(self, w):
         '''
@@ -36,9 +33,9 @@ class _Polyline(object):
         w.indent()
         w.write('clickable: false,')
         w.write('geodesic: true,')
-        w.write('strokeColor: "%s",' % self._color)
-        w.write('strokeOpacity: %f,' % self._edge_alpha)
-        w.write('strokeWeight: %d,' % self._edge_width)
+        if self._color is not None: w.write('strokeColor: "%s",' % self._color)
+        if self._alpha is not None: w.write('strokeOpacity: %f,' % self._alpha)
+        if self._width is not None: w.write('strokeWeight: %d,' % self._width)
         w.write('map: map,')
         w.write('path: [')
         w.indent()

--- a/gmplot/drawables/raw_marker.py
+++ b/gmplot/drawables/raw_marker.py
@@ -1,5 +1,3 @@
-from gmplot.utility import _get_value
-
 class _RawMarker(object):
     def __init__(self, position, icon, **kwargs):
         '''
@@ -12,13 +10,13 @@ class _RawMarker(object):
         Args:
             title (str): Hover-over title of the marker.
             label (str): Label displayed on the marker.
-            draggable (bool): Whether or not the marker is draggable. Defaults to False.
+            draggable (bool): Whether or not the marker is draggable.
         '''
         self._position = position
         self._icon = icon
-        self._title = _get_value(kwargs, ['title'])
-        self._label = _get_value(kwargs, ['label'])
-        self._draggable = _get_value(kwargs, ['draggable'], False)
+        self._title = kwargs.get('title') 
+        self._label = kwargs.get('label')
+        self._draggable = kwargs.get('draggable')
 
     def write(self, w, name=None):
         '''
@@ -38,11 +36,9 @@ class _RawMarker(object):
         w.indent()
         w.write('position: %s,' % self._position)
         w.write('icon: %s,' % self._icon)
-
         if self._title is not None: w.write('title: "%s",' % self._title)
         if self._label is not None: w.write('label: "%s",' % self._label)
-        if self._draggable: w.write('draggable: %s,' % str(self._draggable).lower())
-
+        if self._draggable is True: w.write('draggable: true,')
         w.write('map: map')
         w.dedent()
         w.write('});')

--- a/gmplot/drawables/route.py
+++ b/gmplot/drawables/route.py
@@ -1,26 +1,25 @@
-from gmplot.utility import _get_value, _format_LatLng
+from gmplot.utility import _get, _format_LatLng
 
 class _Route(object):
     '''For more info, see Google Maps' `Directions Service https://developers.google.com/maps/documentation/javascript/directions`_.'''
     
-    def __init__(self, origin, destination, **kwargs):
+    def __init__(self, origin, destination, precision, **kwargs):
         '''
         Args:
             origin ((float, float)): Origin, as a latitude/longitude tuple.
             destination ((float, float)): Destination, as a latitude/longitude tuple.
+            precision (int): Number of digits after the decimal to round to for lat/lng values.
 
         Optional:
 
         Args:
-            travel_mode (str): Travel mode. Defaults to 'DRIVING'.
+            travel_mode (str): Travel mode.
             waypoints ([(float, float)]): Waypoints.
-            precision (int): Number of digits after the decimal to round to for lat/lng values. Defaults to 6.
         '''
-        precision = _get_value(kwargs, ['precision'], 6)
         self._origin = _format_LatLng(*origin, precision=precision)
         self._destination = _format_LatLng(*destination, precision=precision)
-        self._travel_mode = _get_value(kwargs, ['travel_mode'], 'DRIVING').upper()
-        self._waypoints = [_format_LatLng(*waypoint, precision=precision) for waypoint in _get_value(kwargs, ['waypoints'], [])]
+        self._travel_mode = kwargs.get('travel_mode')
+        self._waypoints = [_format_LatLng(*waypoint, precision=precision) for waypoint in _get(kwargs, ['waypoints'], [])]
 
     def write(self, w):
         '''
@@ -31,6 +30,7 @@ class _Route(object):
         '''
         w.write('new google.maps.DirectionsService().route({')
         w.indent()
+        if self._travel_mode is not None: w.write('travelMode: "%s",' % self._travel_mode.upper())
         w.write('origin: %s,' % self._origin)
         w.write('destination: %s,' % self._destination)
         if self._waypoints:
@@ -38,8 +38,7 @@ class _Route(object):
             w.indent()
             [w.write('{location: %s, stopover: false},' % waypoint) for waypoint in self._waypoints]
             w.dedent()
-            w.write('],')
-        w.write('travelMode: "%s"' % self._travel_mode)
+            w.write(']')
         w.dedent()
         w.write('''  
             }, function(response, status) {

--- a/gmplot/drawables/symbol.py
+++ b/gmplot/drawables/symbol.py
@@ -1,6 +1,3 @@
-from gmplot.color import _get_hex_color
-from gmplot.utility import _get_value
-
 from gmplot.drawables.symbols.circle import _Circle
 from gmplot.drawables.symbols.plus import _Plus
 from gmplot.drawables.symbols.x import _X
@@ -12,47 +9,30 @@ class _Symbol(object):
         'x': _X
     }
 
-    @staticmethod
-    def is_valid(shape):
-        '''
-        Return whether or not a shape is valid.
-
-        Args:
-            shape (str): Shape of a symbol.
-        
-        Returns:
-            bool: True if the shape is valid, False otherwise.
-        '''
-        return shape in _Symbol._SHAPES
-
-    def __init__(self, shape, lat, lng, size, **kwargs):
+    def __init__(self, lat, lng, shape, size, precision, **kwargs):
         '''
         Args:
-            shape (str): Shape of the symbol, as 'o', 'x', or '+'.
             lat (float): Latitude of the center of the symbol.
             lng (float): Longitude of the center of the symbol.
+            shape (str): Shape of the symbol, as 'o', 'x', or '+'.
             size (int): Size of the symbol, in meters.
+            precision (int): Number of digits after the decimal to round to for lat/lng values.
 
         Optional:
 
         Args:
-            color/c/edge_color/ec (str): Color of the symbol's edge.
-                Can be hex ('#00FFFF'), named ('cyan'), or matplotlib-like ('c'). Defaults to black.
-            alpha/edge_alpha/ea (float): Opacity of the symbol's edge, ranging from 0 to 1. Defaults to 1.0.
-            edge_width/ew (int): Width of the symbol's edge, in pixels. Defaults to 1.
-            color/c/face_color/fc (str): Color of the symbol's face.
-                Can be hex ('#00FFFF'), named ('cyan'), or matplotlib-like ('c'). Defaults to black.
-            alpha/face_alpha/fa (float): Opacity of the symbol's face, ranging from 0 to 1. Defaults to 0.5.
-            precision (int): Number of digits after the decimal to round to for lat/lng values. Defaults to 6.
+            edge_color (str): Color of the symbol's edge. Can be hex ('#00FFFF'), named ('cyan'), or matplotlib-like ('c').
+            edge_alpha (float): Opacity of the symbol's edge, ranging from 0 to 1.
+            edge_width (int): Width of the symbol's edge, in pixels.
+            face_color (str): Color of the symbol's face. Can be hex ('#00FFFF'), named ('cyan'), or matplotlib-like ('c').
+            face_alpha (float): Opacity of the symbol's face, ranging from 0 to 1.
         '''
-        kwargs.setdefault('edge_color', _get_hex_color(_get_value(kwargs, ['color', 'c', 'edge_color', 'ec'], 'black')))
-        kwargs.setdefault('edge_alpha', _get_value(kwargs, ['alpha', 'edge_alpha', 'ea'], 1.0))
-        kwargs.setdefault('edge_width', _get_value(kwargs, ['edge_width', 'ew'], 1))
-        kwargs.setdefault('face_color', _get_hex_color(_get_value(kwargs, ['color', 'c', 'face_color', 'fc'], 'black')))
-        kwargs.setdefault('face_alpha', _get_value(kwargs, ['alpha', 'face_alpha', 'fa'], 0.5))
-        kwargs.setdefault('precision', _get_value(kwargs, ['precision'], 6))
+        # Copy parameters for symbols without a face:
+        kwargs['color'] = kwargs.get('edge_color')
+        kwargs['alpha'] = kwargs.get('edge_alpha')
+        kwargs['width'] = kwargs.get('edge_width')
 
-        self._symbol = self._SHAPES[shape](lat, lng, size, **kwargs)
+        self._symbol = self._SHAPES[shape](lat, lng, size, precision, **kwargs)
 
     def write(self, w):
         '''

--- a/gmplot/drawables/symbols/plus.py
+++ b/gmplot/drawables/symbols/plus.py
@@ -1,39 +1,31 @@
 import math
 
-from gmplot.color import _get_hex_color
-from gmplot.utility import _get_value
 from gmplot.drawables.polyline import _Polyline
 
 _EARTH_RADIUS_IN_KM = 6378.8 # TODO: Avoid duplicating this constant.
 
 class _Plus(object):
-    def __init__(self, lat, lng, size, **kwargs):
+    def __init__(self, lat, lng, size, precision, **kwargs):
         '''
         Args:
             lat (float): Latitude of the center of the '+'.
             lng (float): Longitude of the center of the '+'.
             size (int): Size of the '+', in meters.
+            precision (int): Number of digits after the decimal to round to for lat/lng values.
 
         Optional:
 
         Args:
-            color/c/edge_color/ec (str): Color of the '+''s edge.
-                Can be hex ('#00FFFF'), named ('cyan'), or matplotlib-like ('c'). Defaults to black.
-            alpha/edge_alpha/ea (float): Opacity of the '+''s edge, ranging from 0 to 1. Defaults to 1.0.
-            edge_width/ew (int): Width of the '+''s edge, in pixels. Defaults to 1.
-            precision (int): Number of digits after the decimal to round to for lat/lng values. Defaults to 6.
+            color (str): Color of the '+'. Can be hex ('#00FFFF'), named ('cyan'), or matplotlib-like ('c').
+            alpha (float): Opacity of the '+', ranging from 0 to 1.
+            width (int): Width of the '+''s edge, in pixels.
         '''
-        kwargs.setdefault('edge_color', _get_hex_color(_get_value(kwargs, ['color', 'c', 'edge_color', 'ec'], 'black')))
-        kwargs.setdefault('edge_alpha', _get_value(kwargs, ['alpha', 'edge_alpha', 'ea'], 1.0))
-        kwargs.setdefault('edge_width', _get_value(kwargs, ['edge_width', 'ew'], 1))
-        kwargs.setdefault('precision', _get_value(kwargs, ['precision'], 6))
-
         # TODO: The following generates a '+' in Cartesian frame rather than in lat/lng; avoid this.
         delta_lat = (size / 1000.0 / _EARTH_RADIUS_IN_KM) * (180.0 / math.pi)
         delta_lng = delta_lat / math.cos(math.pi * lat / 180.0)
 
-        self._horizontal_stroke = _Polyline([lat, lat], [lng - delta_lng, lng + delta_lng], **kwargs)
-        self._vertical_stroke = _Polyline([lat - delta_lat, lat + delta_lat], [lng, lng], **kwargs)
+        self._horizontal_stroke = _Polyline([lat, lat], [lng - delta_lng, lng + delta_lng], precision, **kwargs)
+        self._vertical_stroke = _Polyline([lat - delta_lat, lat + delta_lat], [lng, lng], precision, **kwargs)
 
     def write(self, w):
         '''

--- a/gmplot/drawables/symbols/x.py
+++ b/gmplot/drawables/symbols/x.py
@@ -1,39 +1,31 @@
 import math
 
-from gmplot.color import _get_hex_color
-from gmplot.utility import _get_value
 from gmplot.drawables.polyline import _Polyline
 
 _EARTH_RADIUS_IN_KM = 6378.8 # TODO: Avoid duplicating this constant.
 
 class _X(object):
-    def __init__(self, lat, lng, size, **kwargs):
+    def __init__(self, lat, lng, size, precision, **kwargs):
         '''
         Args:
             lat (float): Latitude of the center of the 'x'.
             lng (float): Longitude of the center of the 'x'.
             size (int): Size of the 'x', in meters.
+            precision (int): Number of digits after the decimal to round to for lat/lng values.
 
         Optional:
 
         Args:
-            color/c/edge_color/ec (str): Color of the 'x''s edge.
-                Can be hex ('#00FFFF'), named ('cyan'), or matplotlib-like ('c'). Defaults to black.
-            alpha/edge_alpha/ea (float): Opacity of the 'x''s edge, ranging from 0 to 1. Defaults to 1.0.
-            edge_width/ew (int): Width of the 'x''s edge, in pixels. Defaults to 1.
-            precision (int): Number of digits after the decimal to round to for lat/lng values. Defaults to 6.
+            color (str): Color of the 'x'. Can be hex ('#00FFFF'), named ('cyan'), or matplotlib-like ('c').
+            alpha (float): Opacity of the 'x', ranging from 0 to 1.
+            width (int): Width of the 'x''s edge, in pixels.
         '''
-        kwargs.setdefault('edge_color', _get_hex_color(_get_value(kwargs, ['color', 'c', 'edge_color', 'ec'], 'black')))
-        kwargs.setdefault('edge_alpha', _get_value(kwargs, ['alpha', 'edge_alpha', 'ea'], 1.0))
-        kwargs.setdefault('edge_width', _get_value(kwargs, ['edge_width', 'ew'], 1))
-        kwargs.setdefault('precision', _get_value(kwargs, ['precision'], 6))
-
         # TODO: The following generates a 'x' in Cartesian frame rather than in lat/lng; avoid this.
         delta_lat = (size / 1000.0 / _EARTH_RADIUS_IN_KM / math.sqrt(2)) * (180.0 / math.pi)
         delta_lng = delta_lat / math.cos(math.pi * lat / 180.0)
 
-        self._down_right_stroke = _Polyline([lat - delta_lat, lat + delta_lat], [lng + delta_lng, lng - delta_lng], **kwargs)
-        self._up_right_stroke = _Polyline([lat - delta_lat, lat + delta_lat], [lng - delta_lng, lng + delta_lng], **kwargs)
+        self._down_right_stroke = _Polyline([lat - delta_lat, lat + delta_lat], [lng + delta_lng, lng - delta_lng], precision, **kwargs)
+        self._up_right_stroke = _Polyline([lat - delta_lat, lat + delta_lat], [lng - delta_lng, lng + delta_lng], precision, **kwargs)
 
     def write(self, w):
         '''

--- a/gmplot/drawables/text.py
+++ b/gmplot/drawables/text.py
@@ -1,24 +1,24 @@
 from gmplot.color import _get_hex_color
-from gmplot.utility import _COLOR_ICON_PATH, _get_value, _format_LatLng, _get_embeddable_image
+from gmplot.utility import _COLOR_ICON_PATH, _format_LatLng, _get_embeddable_image
 
 class _Text(object):    
-    def __init__(self, lat, lng, text, **kwargs):
+    def __init__(self, lat, lng, text, precision, **kwargs):
         '''
         Args:
             lat (float): Latitude of the text label.
             lng (float): Longitude of the text label.
             text (str): Text to display.
+            precision (int): Number of digits after the decimal to round to for lat/lng values.
 
         Optional:
 
         Args:
-            color/c (str): Text color. Can be hex ('#00FFFF'), named ('cyan'), or matplotlib-like ('c'). Defaults to black.
-            precision (int): Number of digits after the decimal to round to for lat/lng values. Defaults to 6.
+            color (str): Text color. Can be hex ('#00FFFF'), named ('cyan'), or matplotlib-like ('c').
         '''
-        precision = _get_value(kwargs, ['precision'], 6)
         self._position = _format_LatLng(lat, lng, precision)
         self._text = text
-        self._color = _get_hex_color(_get_value(kwargs, ['color', 'c'], 'black'))
+        color = kwargs.get('color')
+        self._color = _get_hex_color(color) if color is not None else None
         self._icon = _get_embeddable_image(_COLOR_ICON_PATH % 'clear')
 
     def write(self, w):
@@ -28,21 +28,18 @@ class _Text(object):
         Args:
             w (_Writer): Writer used to write the text.
         '''
-        w.write('''
-            new google.maps.Marker({{
-                label: {{
-                    text: "{text}",
-                    color: "{color}",
-                    fontWeight: "bold"
-                }},
-                icon: "{icon}",
-                position: {position},
-                map: map
-            }});
-        '''.format(
-            text=self._text,
-            color=self._color,
-            icon=self._icon,
-            position=self._position
-        ))
+        w.write('new google.maps.Marker({')
+        w.indent()
+        w.write('label: {')
+        w.indent()
+        w.write('text: "%s",' % self._text)
+        if self._color is not None: w.write('color: "%s",' % self._color)
+        w.write('fontWeight: "bold"')
+        w.dedent()
+        w.write('},')
+        w.write('icon: "%s",' % self._icon)
+        w.write('position: %s,' % self._position)
+        w.write('map: map')
+        w.dedent()
+        w.write('});')
         w.write()

--- a/gmplot/utility.py
+++ b/gmplot/utility.py
@@ -33,29 +33,30 @@ if sys.version_info.major == 2:
 else:
     from io import StringIO # pragma: no coverage
 
-def _get_value(dict, keys, default=None, get_key=False, pop=False):
+def _get(dict, keys, default=None, get_key=False):
     '''
     Get the value of any of the provided keys.
 
+    Note: Only use `dict.get()` if you have a single key and no optional parameters set,
+          otherwise, prefer this function.
+
     Args:
         dict (dict): Dict to obtain the value from.
-        keys ([str]): Keys of interest, in order of preference.
+        keys (str or [str]): Keys of interest, in order of preference.
 
     Optional:
     
     Args:
         default: Value to return if none of the keys have a value. Defaults to None.
         get_key (bool): Whether or not to also return the key associated with the returned value. Defaults to False.
-        pop (bool): Whether or not to pop the element if it's found. Defaults to False.
 
     Returns:
         any or (str, any): Value of the first valid key, or a tuple of the key and its value if ``get_key`` is True.
             If the default value is returned, the key is None.
     '''
-    for key in keys:
+    for key in (keys if isinstance(keys, (list, tuple)) else [keys]):
         value = dict.get(key)
         if value is not None:
-            if pop: del dict[key]
             return value if not get_key else (key, value)
     return default if not get_key else (None, default)
 

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -1,12 +1,11 @@
 import unittest
-import warnings
-from gmplot.color import _is_valid_hex_color, _get_hex_color
+from gmplot.color import _get_hex_color
 
-class ColorTests(unittest.TestCase):
+class ColorTest(unittest.TestCase):
     def setUp(self):
         self.longMessage = True
 
-    def test_is_valid_hex_color(self):
+    def test_get_hex_color(self):
         # Test valid hex colors:
         VALID_HEX_COLORS = [
             '#000000',
@@ -15,36 +14,35 @@ class ColorTests(unittest.TestCase):
         ]
 
         for color in VALID_HEX_COLORS:
-            self.assertEqual(_is_valid_hex_color(color), True, "'%s' should be a valid hex color" % color)
+            self.assertEqual(_get_hex_color(color), color.upper(), "'%s' should be formatted as uppercase" % color)
 
-        # Test invalid hex colors:
-        INVALID_HEX_COLORS = [
-            '#FC0',
-            '#GFCC00',
-            '#0000000',
-            '11ee22',
-            'red',
-            []
-        ]
-
-        for color in INVALID_HEX_COLORS:
-            self.assertEqual(_is_valid_hex_color(color), False, "'%s' should be an invalid hex color" % color)
-
-    def test_get_hex_color_code(self):
         # Test valid aliases of red:
         for color in ['r', 'red', '#FF0000']:
             self.assertEqual(_get_hex_color(color), '#FF0000', "'%s' should be a valid alias for 'red'" % color)
 
-        # Test invalid colours:
+        # Test invalid colors:
         INVALID_COLORS = [
+            '#FC0',
+            '#GFCC00',
+            '#0000000',
+            '11ee22',
             'colorthatdoesntexist',
             '#abc'
         ]
 
         for color in INVALID_COLORS:
-            with warnings.catch_warnings(record=True) as w:
-                warnings.simplefilter("always")
+            with self.assertRaises(ValueError):
+                _get_hex_color(color)
+                self.fail("'%s' should be an invalid color" % color)
 
-                self.assertEqual(_get_hex_color(color), '#000000', "'%s' should be an invalid color" % color)
-                self.assertEqual(len(w), 1, "'%s' should raise a single warning" % color)
-                self.assertTrue(issubclass(w[-1].category, UserWarning), "'%s' should raise a 'UserWarning'" % color)
+        # Test invalid types:
+        INVALID_TYPES = [
+            [],
+            {},
+            123
+        ]
+
+        for color in INVALID_TYPES:
+            with self.assertRaises(TypeError):
+                _get_hex_color(color)
+                self.fail("'%s' should be an invalid type" % color)

--- a/tests/test_gmplot.py
+++ b/tests/test_gmplot.py
@@ -3,7 +3,7 @@ import warnings
 from gmplot.utility import StringIO, _format_LatLng
 from gmplot.writer import _Writer
 from gmplot.drawables.route import _Route
-from gmplot.google_map_plotter import GoogleMapPlotter, InvalidSymbolError
+from gmplot.google_map_plotter import GoogleMapPlotter
 
 class GMPlotTest(unittest.TestCase):
     def test_format_LatLng(self):
@@ -15,14 +15,14 @@ class GMPlotTest(unittest.TestCase):
 #       it doesn't test if the resulting output can actually be rendered properly in a browser.
 class RouteTest(unittest.TestCase):
     def test_write(self):
-        route = _Route((37.770776,-122.461689), (37.780776,-122.461689))
+        route = _Route((37.770776,-122.461689), (37.780776,-122.461689), 6)
 
         with StringIO() as f:
             with _Writer(f) as writer:
                 route.write(writer)
 
     def test_write_waypoints(self):
-        route = _Route((37.770776,-122.461689), (37.780776,-122.461689), waypoints=[(37.431257,-122.133121)])
+        route = _Route((37.770776,-122.461689), (37.780776,-122.461689), 6, waypoints=[(37.431257,-122.133121)])
 
         with StringIO() as f:
             with _Writer(f) as writer:
@@ -102,7 +102,7 @@ class GoogleMapPlotterTest(unittest.TestCase):
     def test_invalid_symbol(self):
         map = GoogleMapPlotter(37.428, -122.145, 16)
 
-        with self.assertRaises(InvalidSymbolError):
+        with self.assertRaises(KeyError):
             map.scatter(self.PATH_4[0], self.PATH_4[1], s=90, marker=False, alpha=0.9, symbol='z', c='red', edge_width=4)
 
         map.get()


### PR DESCRIPTION
This ensures that internal interfaces are narrow (only accept one specific format) and makes the defaults of API functions immediately clear (avoiding cases where you'd need to dig deep into implementation to piece together all the defaults for a given API).