### PR TITLE
Add '\n' and ' " ' support in marker text

### DIFF
--- a/gmplot/drawables/raw_marker.py
+++ b/gmplot/drawables/raw_marker.py
@@ -14,7 +14,7 @@ class _RawMarker(object):
         '''
         self._position = position
         self._icon = icon
-        self._title = kwargs.get('title') 
+        self._title = kwargs.get('title').replace('\n', '\\n').replace('"', '\\"') 
         self._label = kwargs.get('label')
         self._draggable = kwargs.get('draggable')
 

--- a/gmplot/drawables/raw_marker.py
+++ b/gmplot/drawables/raw_marker.py
@@ -14,7 +14,9 @@ class _RawMarker(object):
         '''
         self._position = position
         self._icon = icon
-        self._title = kwargs.get('title').replace('\n', '\\n').replace('"', '\\"') 
+        self._title = kwargs.get('title')
+        if(self._title != None):
+            self._title = self._title.replace('\n', '\\n').replace('"', '\\"') 
         self._label = kwargs.get('label')
         self._draggable = kwargs.get('draggable')
 


### PR DESCRIPTION
if the string contains '\n' or ' " ' the html of the map will not show anything. In order to avoid this problem it is enough to replace each '\n' with '\\n' and each ' " ' with " \\" ". 