### PR TITLE
Adding encoding parameter (default to utf-8)

### DIFF
--- a/gmplot/google_map_plotter.py
+++ b/gmplot/google_map_plotter.py
@@ -811,7 +811,7 @@ class GoogleMapPlotter(object):
             draggable=_get(kwargs, 'draggable', False)
         )
 
-    def draw(self, file):
+    def draw(self, file, encoding="utf-8"):
         '''
         Draw the HTML map to a file.
 
@@ -827,7 +827,7 @@ class GoogleMapPlotter(object):
 
         .. image:: GoogleMapPlotter.draw.png
         '''
-        with open(file, 'w') as f:
+        with open(file, 'w', encoding=encoding) as f:
             self._write_html(f)
 
     def get(self):


### PR DESCRIPTION
It permits us to use special characters in text we insert in the map, avoiding the error `UnicodeEncodeError: 'charmap' codec can't encode characters in position 19-20` !